### PR TITLE
Enable blur-trim for values bound by multiple fields

### DIFF
--- a/projects/ngx-trim-directive/src/lib/ngx-trim.directive.ts
+++ b/projects/ngx-trim-directive/src/lib/ngx-trim.directive.ts
@@ -42,6 +42,8 @@ export class NgxTrimDirective implements OnInit, OnDestroy {
     return this._trim;
   }
 
+  @Input() trimOnWriteValue: boolean = true;
+
   private _valueAccessor: ControlValueAccessor;
   private _writeValue: (value) => void;
 
@@ -99,10 +101,10 @@ export class NgxTrimDirective implements OnInit, OnDestroy {
 
     this._writeValue = this._valueAccessor.writeValue;
     this._valueAccessor.writeValue = (value) => {
-
-      const _value = this.trim === false || !value || !value.trim
-        ? value
-        : value && value.trim();
+      const _value =
+        this.trim === false || !value || !value.trim || !this.trimOnWriteValue
+          ? value
+          : value && value.trim();
 
       if (this._writeValue) {
         this._writeValue.call(this._valueAccessor, _value);

--- a/projects/ngx-trim-directive/src/test/ngx-trim.directive.spec.ts
+++ b/projects/ngx-trim-directive/src/test/ngx-trim.directive.spec.ts
@@ -13,6 +13,8 @@ import {
   async,
   ComponentFixture,
   TestBed,
+  fakeAsync,
+  tick,
 } from '@angular/core/testing';
 
 import { NgxTrimDirective } from '../lib';
@@ -28,6 +30,19 @@ import { NgxTrimDirective } from '../lib';
       <input type="text" #input3 formControlName="fieldB" trim="blur">
       <input type="text" #input4 formControlName="fieldC" [trim]="trimOption">
     </div>
+    <input
+      type="text"
+      #inputModelValueBoundTwice1
+      [(ngModel)]="modelValueBoundTwice"
+      trim="blur"
+      [trimOnWriteValue]="trimOnWriteValue"
+    />
+    <input
+      type="text"
+      [(ngModel)]="modelValueBoundTwice"
+      trim="blur"
+      [trimOnWriteValue]="trimOnWriteValue"
+    />
   `,
 })
 class TestComponent {
@@ -36,8 +51,11 @@ class TestComponent {
   @ViewChild('input2', { static: false }) input2: ElementRef;
   @ViewChild('input3', { static: false }) input3: ElementRef;
   @ViewChild('input4', { static: false }) input4: ElementRef;
+  @ViewChild('inputModelValueBoundTwice1', { static: false }) inputModelValueBoundTwice1: ElementRef;
 
   trimOption: '' | 'blur' | false = '';
+  trimOnWriteValue = true;
+
   readonly fieldA = new FormControl('ngxTrimDirective   ');
   readonly formA = new FormGroup({
     fieldA: this.fieldA,
@@ -55,6 +73,7 @@ class TestComponent {
   uninitializedValue: string;
 
   value = '   ngxTrimDirective';
+  modelValueBoundTwice = "";
 }
 
 describe('NgxTrimDirective', () => {
@@ -231,5 +250,27 @@ describe('NgxTrimDirective', () => {
     expect(el4.value).toBe('ngxTrimDirective   ');
     expect(component.fieldC.value).toBe('ngxTrimDirective   ');
   });
+
+  it('should trim the model value on input if trimOnWriteValue is true', fakeAsync(() => {
+    component.trimOnWriteValue = true;
+    const el1 = component.inputModelValueBoundTwice1.nativeElement;
+    const newValue = `ngxTrimDirective `;
+    el1.value = newValue;
+    el1.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    tick();
+    expect(component.modelValueBoundTwice).toBe(newValue.trim());
+  }));
+
+  it('should not trim the model value on input if trimOnWriteValue is false', fakeAsync(() => {
+    component.trimOnWriteValue = false;
+    const el1 = component.inputModelValueBoundTwice1.nativeElement;
+    const newValue = `ngxTrimDirective `;
+    el1.value = newValue;
+    el1.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    tick();
+    expect(component.modelValueBoundTwice).toBe(newValue);
+  }));
 
 });


### PR DESCRIPTION
My pull request as discussed here: https://github.com/KingMario/packages/issues/13
Binding the same value by multiple input fields lets _writeValue()_ be called by _ControlValueAccessor_  which trims the value.
To be able to only trim the value bound by multiple input fields on blur I implemented an option to disable the trim in _writeValue()_ of _ControlValueAccessor_ by setting _trimOnWriteValue_ to _false_.